### PR TITLE
feat: :technologist: Add className property to custom sections

### DIFF
--- a/src/components/Section.astro
+++ b/src/components/Section.astro
@@ -1,11 +1,12 @@
 ---
 type Props = {
     noHeader?: boolean;
+    className?: string;
 };
-const { noHeader } = Astro.props;
+const { noHeader, className =""} = Astro.props;
 ---
 
-<section class="custom-section">
+<section class={`custom-section ${className}`}>
     {
         !noHeader && (
             <div class="custom-section__header">


### PR DESCRIPTION
Add a property called className to allow to add classes in a Section component to improve the identifying of these components in CSS